### PR TITLE
Add automated PyPI publishing and security scanning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,98 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write  # Required for trusted publishing
+
+jobs:
+  test-before-publish:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Get version from pyproject.toml
+        id: get-version
+        run: |
+          VERSION=$(grep "^version" pyproject.toml | cut -d'"' -f2)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Building version: $VERSION"
+      
+      - name: Verify version matches tag
+        run: |
+          TAG_VERSION="${{ github.event.release.tag_name }}"
+          TAG_VERSION="${TAG_VERSION#v}"  # Remove 'v' prefix
+          if [ "${{ steps.get-version.outputs.version }}" != "$TAG_VERSION" ]; then
+            echo "Version mismatch: pyproject.toml=${{ steps.get-version.outputs.version }}, tag=$TAG_VERSION"
+            exit 1
+          fi
+      
+      - name: Build Docker image with test deps
+        run: |
+          docker build \
+            --pull \
+            --tag asmf-ci:${{ steps.get-version.outputs.version }} \
+            --build-arg INSTALL_TEST_DEPS=true \
+            .
+      
+      - name: Run full test suite
+        run: |
+          docker run --rm \
+            -v $(pwd):/workspace/output \
+            asmf-ci:${{ steps.get-version.outputs.version }} \
+            pytest -n auto --cov=src/asmf --cov-report=xml:output/coverage.xml --cov-report=term
+
+  build:
+    needs: test-before-publish
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      
+      - name: Install build dependencies
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          export PATH="/root/.local/bin:$PATH"
+          uv pip install --system build twine
+      
+      - name: Build package
+        run: python -m build
+      
+      - name: Check package contents
+        run: |
+          twine check dist/*
+          tar -tzf dist/*.tar.gz | head -20
+      
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/ai-search-match-framework
+    
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          print-hash: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,44 @@
+name: Security Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Run weekly on Mondays at 9am UTC
+    - cron: '0 9 * * 1'
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      
+      - name: Install security tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install bandit safety pip-audit
+      
+      - name: Run Bandit (code security scanner)
+        run: |
+          bandit -r src/asmf -ll
+        continue-on-error: true
+      
+      - name: Check for known vulnerabilities in dependencies
+        run: |
+          pip-audit --desc
+        continue-on-error: true
+      
+      - name: Scan for secrets
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2025-12-14
+
+### Added
+- BaseAnalyzer abstract class for domain-specific analyzers
+- Automated CI/CD with GitHub Actions
+- Docker-based testing with pytest-xdist for parallel execution
+- Automated version tagging and GitHub Releases
+- PyPI publishing workflow with trusted publishing
+- Security scanning (Bandit, pip-audit, TruffleHog)
+- Comprehensive documentation (PUBLISHING.md, RELEASE_CHECKLIST.md)
+- Code coverage reporting (75% minimum threshold)
+- Multi-version Python testing (3.10, 3.11, 3.12)
+
+### Changed
+- Restructured project: moved app code to `examples/job_finder/`
+- Rewrote README focusing on framework (not job application)
+- Updated metadata in pyproject.toml (author, keywords, URLs)
+- Improved PDF parser title extraction logic
+- Enhanced provider tests with comprehensive mocking
+
+### Fixed
+- PDF parser now correctly handles all-caps titles
+- PDF parser returns empty list instead of error when claims missing
+
+## [0.1.0] - 2024-XX-XX
+
+### Added
+- Initial framework structure
+- AI Provider system (Gemini, Ollama)
+- PDF parsing for patent documents
+- Basic analyzers
+- Test suite with pytest
+- Example job finder application
+
+[0.2.0]: https://github.com/vcaboara/ai-search-match-framework/releases/tag/v0.2.0
+[0.1.0]: https://github.com/vcaboara/ai-search-match-framework/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -199,30 +199,42 @@ uv run pytest tests/test_job_finder.py
 
 ## Security
 
-- No PII in repository
-- API keys via environment variables
+- No PII in repository (automated scans)
+- API keys via environment variables only
 - Input validation and sanitization
 - Rate limiting on external APIs
 - CORS protection on web endpoints
+- Trusted PyPI publishing (no API tokens)
+- Weekly vulnerability scans
+
+## Publishing
+
+This framework is published to PyPI with automated workflows:
+- **Auto-tagging**: Merges to `main` create version tags
+- **Auto-publishing**: GitHub Releases trigger PyPI uploads
+- **Pre-publish tests**: Full test suite runs before publishing
+
+See [docs/PUBLISHING.md](docs/PUBLISHING.md) for details.
 
 ## Documentation
 
-- `docs/` - Technical documentation
-- `memory/docs/` - Project context and architecture
-- `memory/tasks/` - Task planning and status
-- `.github/` - AI assistant instructions
+- [docs/PUBLISHING.md](docs/PUBLISHING.md) - Release process
+- [docs/RELEASE_CHECKLIST.md](docs/RELEASE_CHECKLIST.md) - Pre-release checklist
+- [docs/CONFIGURATION.md](docs/CONFIGURATION.md) - Configuration guide
+- [docs/PATTERNS.md](docs/PATTERNS.md) - Usage patterns
+- `.github/copilot-instructions.md` - Development guidelines
 
 ## License
 
-[Specify your license]
+MIT License - See LICENSE file for details
 
 ## Contributing
 
 1. Follow `.github/copilot-instructions.md` guidelines
-2. Use feature branches
-3. Include tests for new features
-4. Update documentation
-5. Add AI attribution in commits
+2. Use feature branches with descriptive names
+3. Include tests for new features (maintain 75%+ coverage)
+4. Update documentation for API changes
+5. Run pre-commit checks before pushing
 
 ## Credits
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,0 +1,164 @@
+# Publishing to PyPI
+
+This document describes the automated publishing process for the AI Search Match Framework.
+
+## Overview
+
+The framework uses GitHub Actions with PyPI Trusted Publishing for secure, automated releases.
+
+## Publishing Process
+
+### 1. Automatic Tagging (On Merge to Main)
+
+When code is merged to `main`, the `release.yml` workflow automatically:
+- Extracts version from `pyproject.toml`
+- Creates a git tag (e.g., `v0.2.0`)
+- Creates a GitHub Release with auto-generated notes
+
+### 2. Automated PyPI Publishing (On Release)
+
+When a GitHub Release is published, the `publish.yml` workflow:
+
+1. **Pre-publish Tests**: Runs full test suite to ensure package quality
+2. **Version Validation**: Verifies `pyproject.toml` version matches the git tag
+3. **Build**: Creates source distribution (.tar.gz) and wheel (.whl) files
+4. **Package Validation**: Checks package metadata and structure with `twine check`
+5. **Publish**: Uploads to PyPI using Trusted Publishing (no API tokens needed)
+
+## Setup Requirements
+
+### One-Time PyPI Setup
+
+1. **Configure Trusted Publishing on PyPI**:
+   - Go to https://pypi.org/manage/account/publishing/
+   - Add a new "pending publisher":
+     - PyPI Project Name: `ai-search-match-framework`
+     - Owner: `vcaboara`
+     - Repository name: `ai-search-match-framework`
+     - Workflow name: `publish.yml`
+     - Environment name: `pypi`
+
+2. **Create PyPI Environment in GitHub**:
+   - Go to repository Settings → Environments
+   - Create environment named `pypi`
+   - Optional: Add protection rules (e.g., required reviewers)
+
+## Publishing Workflow
+
+### Normal Release Process
+
+1. **Update Version**:
+   ```bash
+   # Edit pyproject.toml version field
+   version = "0.3.0"
+   ```
+
+2. **Create PR with Changes**:
+   ```bash
+   git checkout -b release/v0.3.0
+   git add pyproject.toml
+   git commit -m "chore: bump version to 0.3.0"
+   git push origin release/v0.3.0
+   # Create PR and get it reviewed
+   ```
+
+3. **Merge to Main**:
+   - Merge the PR to `main`
+   - `release.yml` automatically creates tag `v0.3.0` and GitHub Release
+
+4. **Publish to PyPI**:
+   - Go to GitHub Releases
+   - Edit the auto-created release (or create manually if needed)
+   - Click "Publish release"
+   - `publish.yml` runs and publishes to PyPI
+
+### Manual Release (If Needed)
+
+If automatic tagging fails, create manually:
+
+```bash
+git tag -a v0.3.0 -m "Release v0.3.0"
+git push origin v0.3.0
+```
+
+Then create GitHub Release from the tag.
+
+## Testing Locally
+
+Before releasing, test the build locally:
+
+```bash
+# Install build tools
+pip install build twine
+
+# Build package
+python -m build
+
+# Check package
+twine check dist/*
+
+# Inspect contents
+tar -tzf dist/ai-search-match-framework-*.tar.gz
+unzip -l dist/ai_search_match_framework-*.whl
+
+# Test installation locally
+pip install dist/ai_search_match_framework-*.whl
+```
+
+## Version Numbering
+
+Follow [Semantic Versioning](https://semver.org/):
+
+- **MAJOR** version (X.0.0): Incompatible API changes
+- **MINOR** version (0.X.0): New functionality, backward compatible
+- **PATCH** version (0.0.X): Bug fixes, backward compatible
+
+Examples:
+- `0.1.0`: Initial development releases
+- `0.2.0`: Added new features (BaseAnalyzer, CI/CD)
+- `0.2.1`: Bug fixes
+- `1.0.0`: First stable release
+
+## Troubleshooting
+
+### Publishing Fails with "403 Forbidden"
+
+- Verify Trusted Publishing is configured correctly on PyPI
+- Check that the workflow name and environment match exactly
+- Ensure the release is published (not draft)
+
+### Version Mismatch Error
+
+- Ensure `pyproject.toml` version matches the git tag (without 'v' prefix)
+- Tag format: `v0.2.0`, pyproject.toml: `version = "0.2.0"`
+
+### Tests Fail Before Publishing
+
+- Publishing is blocked until all tests pass
+- Fix issues and create a new release after merging fixes
+
+## Security Notes
+
+- **No API Tokens**: Uses PyPI Trusted Publishing (OIDC)
+- **No Secrets**: All authentication via GitHub's OIDC provider
+- **Environment Protection**: Use GitHub environment protection rules for production
+- **PII Check**: Automated checks ensure no credentials in repository
+
+## Monitoring
+
+After publishing:
+
+1. **Verify on PyPI**: https://pypi.org/project/ai-search-match-framework/
+2. **Test Installation**: `pip install ai-search-match-framework`
+3. **Check GitHub Actions**: Review workflow run logs
+4. **Verify Package**: Import and test in clean environment
+
+## Rollback
+
+If a bad version is published:
+
+1. **Yank the release on PyPI** (makes it unavailable for new installs)
+2. **Fix the issue** in a new version
+3. **Publish a patch release** (e.g., 0.2.1)
+
+Note: PyPI does not allow deleting or replacing existing versions.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,76 @@
+# Pre-Release Checklist
+
+Use this checklist before publishing a new release.
+
+## Code Quality
+
+- [ ] All tests pass locally (`pytest`)
+- [ ] Coverage meets threshold (≥75%)
+- [ ] No linting errors (`black --check`, `isort --check`, `flake8`)
+- [ ] Type checking passes (`mypy src/asmf --strict`)
+- [ ] No merge conflicts
+
+## Documentation
+
+- [ ] README.md is up to date
+- [ ] CHANGELOG.md updated with new version
+- [ ] API documentation reflects changes
+- [ ] Examples work with new version
+- [ ] Migration guide (if breaking changes)
+
+## Version & Metadata
+
+- [ ] Version bumped in `pyproject.toml`
+- [ ] Version follows semantic versioning
+- [ ] Dependencies are pinned appropriately
+- [ ] License information is current
+- [ ] Author information is correct
+
+## Security & Privacy
+
+- [ ] No API keys or secrets in code
+- [ ] No PII beyond public contact info
+- [ ] `.gitignore` covers sensitive files
+- [ ] Dependencies have no known vulnerabilities
+- [ ] Environment variables documented
+
+## Testing
+
+- [ ] Unit tests cover new functionality
+- [ ] Integration tests pass
+- [ ] Examples run successfully
+- [ ] Fresh install works: `pip install -e .`
+- [ ] Docker build succeeds
+
+## CI/CD
+
+- [ ] GitHub Actions workflows pass
+- [ ] All PR checks are green
+- [ ] No draft commits or WIP code
+- [ ] Branch is up to date with main
+
+## Release Notes
+
+- [ ] GitHub Release notes prepared
+- [ ] Breaking changes highlighted
+- [ ] Migration instructions clear
+- [ ] Contributors acknowledged
+
+## Post-Release
+
+After publishing to PyPI:
+
+- [ ] Verify package on PyPI
+- [ ] Test fresh install: `pip install ai-search-match-framework`
+- [ ] Check package imports work
+- [ ] Update downstream projects (e.g., job-lead-finder)
+- [ ] Announce release (if applicable)
+
+## Emergency Rollback
+
+If issues are found after release:
+
+1. Yank the version on PyPI (don't delete)
+2. Fix the issue immediately
+3. Publish a patch release
+4. Document the issue and fix

--- a/src/asmf/parsers/pdf_parser.py
+++ b/src/asmf/parsers/pdf_parser.py
@@ -141,7 +141,8 @@ class PDFPatentParser:
         using PDF metadata when available.
         """
         lines = [l.strip() for l in text.split("\n") if l.strip()]
-        section_headers = {"ABSTRACT", "BACKGROUND", "CLAIMS", "FIELD", "SUMMARY", "DESCRIPTION"}
+        section_headers = {"ABSTRACT", "BACKGROUND",
+                           "CLAIMS", "FIELD", "SUMMARY", "DESCRIPTION"}
         skip_keywords = ["patent application", "publication"]
 
         def is_section_header(line: str) -> bool:


### PR DESCRIPTION
## Changes

**Publishing Automation:**
- PyPI publishing workflow with trusted publishing (no API tokens)
- Automated testing before publishing
- Version validation against git tags
- Build artifact management

**Security:**
- Security scanning workflow (Bandit, pip-audit, TruffleHog)
- Weekly scheduled vulnerability scans
- No PII verified in repository

**Documentation:**
- PUBLISHING.md - Complete publishing guide
- RELEASE_CHECKLIST.md - Pre-release checklist
- CHANGELOG.md - Version history
- Updated README with publishing info

## Setup Required

Before first publish, configure PyPI Trusted Publishing (see docs/PUBLISHING.md)

## Testing

- [x] No PII beyond public contact info
- [x] All workflows validated
- [x] Documentation complete
- [x] CHANGELOG updated