### PR TITLE
fix: update labeler.yml for actions/labeler@v5 compatibility

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,30 +2,33 @@
 # See https://github.com/actions/labeler
 
 'component:provider':
-  - src/asmf/providers/**/*
+  - changed-files:
+    - any-glob-to-any-file: 'src/asmf/providers/**/*'
 
 'component:parser':
-  - src/asmf/parsers/**/*
+  - changed-files:
+    - any-glob-to-any-file: 'src/asmf/parsers/**/*'
 
 'component:analyzer':
-  - src/asmf/analyzers/**/*
+  - changed-files:
+    - any-glob-to-any-file: 'src/asmf/analyzers/**/*'
 
 'component:utils':
-  - src/asmf/utils/**/*
+  - changed-files:
+    - any-glob-to-any-file: 'src/asmf/utils/**/*'
 
 'documentation':
-  - '**/*.md'
-  - docs/**/*
+  - changed-files:
+    - any-glob-to-any-file: ['**/*.md', 'docs/**/*']
 
 'testing':
-  - tests/**/*
-  - '**/*test*.py'
+  - changed-files:
+    - any-glob-to-any-file: ['tests/**/*', '**/*test*.py']
 
 'ci':
-  - .github/workflows/**/*
-  - .github/**/*.yml
-  - Dockerfile
+  - changed-files:
+    - any-glob-to-any-file: ['.github/workflows/**/*', '.github/**/*.yml', 'Dockerfile']
 
 'dependencies':
-  - pyproject.toml
-  - requirements*.txt
+  - changed-files:
+    - any-glob-to-any-file: ['pyproject.toml', 'requirements*.txt']


### PR DESCRIPTION
## Problem
All Dependabot PRs (#6-10) are failing the 'Auto Label' workflow check with this error:
\\\
Error: found unexpected type for label 'component:provider' (should be array of config options)
\\\

## Solution
The newer version of actions/labeler (v5) requires a different configuration format. Updated labeler.yml from:
\\\yaml
'component:provider':
  - src/asmf/providers/**/*
\\\

To:
\\\yaml
'component:provider':
  - changed-files:
    - any-glob-to-any-file: 'src/asmf/providers/**/*'
\\\

## Impact
-  Fixes failing Auto Label checks on PRs #6, #7, #8, #9, #10
-  Maintains all existing labeling functionality
-  Compatible with actions/labeler@v5

## Testing
Once this PR is merged, the Dependabot PRs should automatically re-run and pass the Auto Label check.