### PR TITLE
fix: Respect OLLAMA_MODEL env var in OllamaProvider

### DIFF
--- a/src/asmf/providers/ollama_provider.py
+++ b/src/asmf/providers/ollama_provider.py
@@ -32,7 +32,7 @@ class OllamaProvider(BaseAIProvider):
         self.base_url = base_url or os.getenv(
             "OLLAMA_BASE_URL", "http://localhost:11434"
         )
-        self.model = model or "qwen2.5-coder:32b"
+        self.model = model or os.getenv("OLLAMA_MODEL", "qwen2.5-coder:32b")
         self.timeout = timeout or float(os.getenv("OLLAMA_TIMEOUT", "300.0"))
         self._available = False
 


### PR DESCRIPTION
## Summary

Makes OllamaProvider consistent with ollama_pr_review.py script by respecting OLLAMA_MODEL environment variable.

## Changes

- Changed default model initialization to check OLLAMA_MODEL env var before falling back to hardcoded default
- Aligns with pattern used for OLLAMA_BASE_URL and OLLAMA_TIMEOUT
- Consistent with ollama_pr_review.py script behavior

## Before

```python
self.model = model or "qwen2.5-coder:32b"
```

## After

```python
self.model = model or os.getenv("OLLAMA_MODEL", "qwen2.5-coder:32b")
```

## Benefits

- Users can configure model without code changes
- Consistent configuration pattern across all providers
- Easier testing with different models
